### PR TITLE
Update jQuery dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "~1.11.0"
+    "jquery": "~1.x"
   },
   "devDependencies": {
     "font-awesome": "~4.2.0"


### PR DESCRIPTION
To play nicely with other jQuery packages like jquery.cookie, jquery-timeago and jquery-waypoints it can use any version of jQuery 1.x, possibly even 2 or 3
